### PR TITLE
Worldmap and File Fixes

### DIFF
--- a/flow.json
+++ b/flow.json
@@ -8096,11 +8096,11 @@
         "type": "inject",
         "z": "407d2b774fe67647",
         "g": "d48758cdf0c8991d",
-        "name": "Inject Legend",
+        "name": "Inject Legend and Center Button",
         "props": [
             {
                 "p": "payload.command",
-                "v": "{\"legend\":\"<b>Band Pin Color</b></br> <i style=\\\"background: #00FF00\\\"></i> 2M<br> <i style=\\\"background: #FFFFFF\\\"></i> 6M<br> <i style=\\\"background: #FF8C00\\\"></i> 10M<br> <i style=\\\"background: #FFFF00\\\"></i> 15M<br> <i style=\\\"background: #FF0000\\\"></i> 20M<br> <i style=\\\"background: #0000FF\\\"></i> 40M<br> <i style=\\\"background: #008000\\\"></i> 80M<br> <i style=\\\"background: #800080\\\"></i> 160M<br> <i style=\\\"background: #000000\\\"></i> Else<br> \"}",
+                "v": "{\"legend\":\"<b>Band Pin Color</b></br> <i style=\\\"background: #00FF00\\\"></i> 2M<br> <i style=\\\"background: #FFFFFF\\\"></i> 6M<br> <i style=\\\"background: #FF8C00\\\"></i> 10M<br> <i style=\\\"background: #FFFF00\\\"></i> 15M<br> <i style=\\\"background: #FF0000\\\"></i> 20M<br> <i style=\\\"background: #0000FF\\\"></i> 40M<br> <i style=\\\"background: #008000\\\"></i> 80M<br> <i style=\\\"background: #800080\\\"></i> 160M<br> <i style=\\\"background: #000000\\\"></i> Else<br> \",\"button\":{\"name\":\"Center Map\",\"icon\":\"fa-square\",\"position\":\"topleft\"}}",
                 "vt": "json"
             },
             {
@@ -8111,9 +8111,9 @@
         "repeat": "10",
         "crontab": "",
         "once": true,
-        "onceDelay": "1",
+        "onceDelay": "2",
         "topic": "",
-        "x": 1120,
+        "x": 1320,
         "y": 160,
         "wires": [
             [
@@ -8143,8 +8143,8 @@
         "topic": "",
         "payload": "",
         "payloadType": "date",
-        "x": 1110,
-        "y": 120,
+        "x": 1170,
+        "y": 40,
         "wires": [
             [
                 "1fef8af3224d3ace"
@@ -10360,28 +10360,24 @@
         "type": "inject",
         "z": "407d2b774fe67647",
         "g": "d48758cdf0c8991d",
-        "name": "Center Map Button",
+        "name": "Center Map Command",
         "props": [
             {
-                "p": "payload.command",
-                "v": "{ \"button\": { \"name\":\"Center Map\", \"icon\":\"ma-home\", \"position\":\"topleft\"} }",
-                "vt": "json"
-            },
-            {
-                "p": "topic",
+                "p": "payload.name",
+                "v": "Center Map",
                 "vt": "str"
             }
         ],
-        "repeat": "10",
+        "repeat": "",
         "crontab": "",
         "once": true,
-        "onceDelay": 0.1,
+        "onceDelay": "6",
         "topic": "",
-        "x": 1170,
-        "y": 80,
+        "x": 1020,
+        "y": 140,
         "wires": [
             [
-                "a6f01856669d3e50"
+                "b0d18fa59cc49c12"
             ]
         ]
     },
@@ -27118,7 +27114,7 @@
         "type": "function",
         "z": "204548a488401a1b",
         "name": "Get Lat & Lon",
-        "func": "let homelat = global.get('homelat')\nlet homelon = global.get('homelon')\n\nif (homelat == '' || homelon == '')\n{\n    msg.payload = \"Home Lat & Lon Not Set\"\n}\nelse\n{\n    msg.payload = homelat + ',' + homelon\n}\n\nreturn msg;",
+        "func": "let homelat = global.get('homelat')\nlet homelon = global.get('homelon')\n\nif (homelat.toString() == '' || homelon.toString() == '')\n{\n    msg.payload = \"Home Lat & Lon Not Set\";\n }\nelse\n{\n    msg.payload = homelat + ',' + homelon\n}\n\nreturn msg;",
         "outputs": 1,
         "noerr": 0,
         "initialize": "",

--- a/flow.json
+++ b/flow.json
@@ -772,7 +772,10 @@
             "f2b91a5dc28385a9",
             "b0d18fa59cc49c12",
             "0d35873cadebf97f",
-            "aa3604030c538a2a"
+            "415b4ee138125e2e",
+            "aa3604030c538a2a",
+            "bc661ac4152269b3",
+            "ae7413cce68dfffa"
         ],
         "x": 274,
         "y": -1,
@@ -10356,6 +10359,21 @@
         ]
     },
     {
+        "id": "415b4ee138125e2e",
+        "type": "ui_ui_control",
+        "z": "407d2b774fe67647",
+        "g": "d48758cdf0c8991d",
+        "name": "",
+        "events": "all",
+        "x": 700,
+        "y": 160,
+        "wires": [
+            [
+                "bc661ac4152269b3"
+            ]
+        ]
+    },
+    {
         "id": "aa3604030c538a2a",
         "type": "inject",
         "z": "407d2b774fe67647",
@@ -10364,17 +10382,71 @@
         "props": [
             {
                 "p": "payload.name",
-                "v": "Center Map",
+                "v": "",
                 "vt": "str"
             }
         ],
         "repeat": "",
         "crontab": "",
         "once": true,
-        "onceDelay": "6",
+        "onceDelay": "15",
         "topic": "",
-        "x": 1020,
-        "y": 140,
+        "x": 880,
+        "y": 100,
+        "wires": [
+            [
+                "415b4ee138125e2e"
+            ]
+        ]
+    },
+    {
+        "id": "bc661ac4152269b3",
+        "type": "change",
+        "z": "407d2b774fe67647",
+        "g": "d48758cdf0c8991d",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "{\"name\":\"Center Map\"}",
+                "tot": "json"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 880,
+        "y": 160,
+        "wires": [
+            [
+                "ae7413cce68dfffa"
+            ]
+        ]
+    },
+    {
+        "id": "ae7413cce68dfffa",
+        "type": "delay",
+        "z": "407d2b774fe67647",
+        "g": "d48758cdf0c8991d",
+        "name": "",
+        "pauseType": "delay",
+        "timeout": "3",
+        "timeoutUnits": "seconds",
+        "rate": "1",
+        "nbRateUnits": "1",
+        "rateUnits": "second",
+        "randomFirst": "1",
+        "randomLast": "5",
+        "randomUnits": "seconds",
+        "drop": false,
+        "allowrate": false,
+        "outputs": 1,
+        "x": 1060,
+        "y": 160,
         "wires": [
             [
                 "b0d18fa59cc49c12"
@@ -27114,7 +27186,7 @@
         "type": "function",
         "z": "204548a488401a1b",
         "name": "Get Lat & Lon",
-        "func": "let homelat = global.get('homelat')\nlet homelon = global.get('homelon')\n\nif (homelat.toString() == '' || homelon.toString() == '')\n{\n    msg.payload = \"Home Lat & Lon Not Set\";\n }\nelse\n{\n    msg.payload = homelat + ',' + homelon\n}\n\nreturn msg;",
+        "func": "let homelat = global.get('homelat')\nlet homelon = global.get('homelon')\n\nif (homelat.toString() == '' || homelon.toString() == '')\n{\n    msg.payload = \"Home Lat & Lon Not Set\";\n    msg.testlat= homelat;\n    msg.testlon= homelon;\n}\nelse\n{\n    msg.payload = homelat + ',' + homelon\n}\n\nreturn msg;",
         "outputs": 1,
         "noerr": 0,
         "initialize": "",
@@ -30575,12 +30647,12 @@
         "id": "1f45eb9a.6f2614",
         "type": "tcp request",
         "z": "bd8a446b999750f9",
+        "name": "NO DUPS VE7CC",
         "server": "dxc.ve7cc.net",
         "port": "23",
         "out": "sit",
         "ret": "buffer",
         "splitc": " ",
-        "name": "NO DUPS VE7CC",
         "x": 850,
         "y": 320,
         "wires": [
@@ -31059,12 +31131,12 @@
         "id": "d5736e14014e7e71",
         "type": "tcp request",
         "z": "bd8a446b999750f9",
+        "name": "Wtih DUPS W3LPL",
         "server": "w3lpl.net",
         "port": "7373",
         "out": "sit",
         "ret": "buffer",
         "splitc": " ",
-        "name": "Wtih DUPS W3LPL",
         "x": 810,
         "y": 620,
         "wires": [
@@ -37406,28 +37478,6 @@
             ]
         ]
     },
-    { 
-        "id": "8fef24f610992b8e",
-        "type": "gate",
-        "z": "3968f5792af364de",
-        "name": "",
-        "controlTopic": "control",
-        "defaultState": "open",
-        "openCmd": "open",
-        "closeCmd": "close",
-        "toggleCmd": "toggle",
-        "defaultCmd": "default",
-        "statusCmd": "status",
-        "persist": true,
-        "storeName": "memory",
-        "x": 830,
-        "y": 180,
-        "wires": [
-            [
-                "3b6d91307549713b"
-            ]
-        ]
-    },
     {
         "id": "3b6d91307549713b",
         "type": "udp out",
@@ -37591,28 +37641,6 @@
             [
                 "54931d388d71eb79",
                 "bcb48af62a6314d3"
-            ]
-        ]
-    },
-    {
-        "id": "7cc70ad33a74db3e",
-        "type": "gate",
-        "z": "3968f5792af364de",
-        "name": "",
-        "controlTopic": "control",
-        "defaultState": "open",
-        "openCmd": "open",
-        "closeCmd": "close",
-        "toggleCmd": "toggle",
-        "defaultCmd": "default",
-        "statusCmd": "status",
-        "persist": true,
-        "storeName": "memory",
-        "x": 1010,
-        "y": 380,
-        "wires": [
-            [
-                "508fa6db79205795"
             ]
         ]
     },
@@ -37808,28 +37836,6 @@
         ]
     },
     {
-        "id": "34159e15a003b83e",
-        "type": "gate",
-        "z": "3968f5792af364de",
-        "name": "",
-        "controlTopic": "control",
-        "defaultState": "open",
-        "openCmd": "open",
-        "closeCmd": "close",
-        "toggleCmd": "toggle",
-        "defaultCmd": "default",
-        "statusCmd": "status",
-        "persist": true,
-        "storeName": "memory",
-        "x": 1010,
-        "y": 600,
-        "wires": [
-            [
-                "b5e6b3c2f3728989"
-            ]
-        ]
-    },
-    {
         "id": "b5e6b3c2f3728989",
         "type": "udp out",
         "z": "3968f5792af364de",
@@ -37891,6 +37897,72 @@
         "x": 1620,
         "y": 400,
         "wires": []
+    },
+    {
+        "id": "8fef24f610992b8e",
+        "type": "gate",
+        "z": "3968f5792af364de",
+        "name": "",
+        "controlTopic": "control",
+        "defaultState": "open",
+        "openCmd": "open",
+        "closeCmd": "close",
+        "toggleCmd": "toggle",
+        "defaultCmd": "default",
+        "statusCmd": "status",
+        "persist": true,
+        "storeName": "memory",
+        "x": 830,
+        "y": 180,
+        "wires": [
+            [
+                "3b6d91307549713b"
+            ]
+        ]
+    },
+    {
+        "id": "7cc70ad33a74db3e",
+        "type": "gate",
+        "z": "3968f5792af364de",
+        "name": "",
+        "controlTopic": "control",
+        "defaultState": "open",
+        "openCmd": "open",
+        "closeCmd": "close",
+        "toggleCmd": "toggle",
+        "defaultCmd": "default",
+        "statusCmd": "status",
+        "persist": true,
+        "storeName": "memory",
+        "x": 1010,
+        "y": 380,
+        "wires": [
+            [
+                "508fa6db79205795"
+            ]
+        ]
+    },
+    {
+        "id": "34159e15a003b83e",
+        "type": "gate",
+        "z": "3968f5792af364de",
+        "name": "",
+        "controlTopic": "control",
+        "defaultState": "open",
+        "openCmd": "open",
+        "closeCmd": "close",
+        "toggleCmd": "toggle",
+        "defaultCmd": "default",
+        "statusCmd": "status",
+        "persist": true,
+        "storeName": "memory",
+        "x": 1010,
+        "y": 600,
+        "wires": [
+            [
+                "b5e6b3c2f3728989"
+            ]
+        ]
     },
     {
         "id": "5e4d47c711482436",

--- a/flow.json
+++ b/flow.json
@@ -34075,7 +34075,8 @@
         "type": "file",
         "z": "3e52b5d54104d7f0",
         "name": "",
-        "filename": "/home/pi/global.json",
+        "filename": "global.json",
+        "filenameType": "str",
         "appendNewline": true,
         "createDir": false,
         "overwriteFile": "true",
@@ -34094,8 +34095,10 @@
         "type": "file in",
         "z": "3e52b5d54104d7f0",
         "name": "",
-        "filename": "/home/pi/global.json",
+        "filename": "global.json",
+        "filenameType": "str",
         "format": "utf8",
+        "allProps": false,
         "x": 580,
         "y": 500,
         "wires": [
@@ -37403,7 +37406,7 @@
             ]
         ]
     },
-    {
+    { 
         "id": "8fef24f610992b8e",
         "type": "gate",
         "z": "3968f5792af364de",


### PR DESCRIPTION
Below I address solutions to #7 and #8 

#7 
As @KK1L mentioned files were dependent upon a pi user.  In this PR, the file is written as a relative file compared to the absolute directory.

See note from NR Dialog 
![image](https://user-images.githubusercontent.com/65520146/202068614-c1ba00fd-bccc-4628-9e6c-a68b2fc5b08b.png)

For Linux users that install Node-Red from the bash script hosted by NR (Also includes the Node-Red-Contest-Dashboard Script hosted by me.) This allows Windows users to save and read the file with no issues. The location of that file would need to be found and documented for Windows Usage.

#8 

As @kylekrieg fixed a temporary solution to all users to manually center the map, I added nodes to the flow to allow the browser to automatically recenter the map on any browser refresh, connection add or drop, or change page in dashboard. This is also a temp fix as it should be limited to only when users are actively visiting a page with a dashboard located on it. 
